### PR TITLE
feat(Client.php): add batchMutation and batchQuery methods that utilizes the multiple graphql queries/mutations in one graphql request

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -122,6 +122,16 @@ class Client
         return $this->call('query', $method, $arguments, $body);
     }
 
+    public function batchMutation(array $operations, bool $throwOnOperationErrors = false): array
+    {
+        return $this->batchCall('mutation', $operations, $throwOnOperationErrors);
+    }
+
+    public function batchQuery(array $operations, bool $throwOnOperationErrors = false): array
+    {
+        return $this->batchCall('query', $operations, $throwOnOperationErrors);
+    }
+
     /**
      * @throws ClientExceptionInterface
      * @throws ErrorException
@@ -185,6 +195,189 @@ class Client
             $this->logger->error($statusCode.': '.$responseBody, [$url, $body]);
             throw new ServerException($this->lastRequest, $this->lastResponse);
         }
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws ErrorException
+     * @throws AuthenticationException
+     * @throws ServerException
+     */
+    public function batchCall(string $type, array $operations, bool $throwOnOperationErrors = false): array
+    {
+        if(!$this->isAuthenticated()) {
+            $this->authenticate();
+        }
+
+        $readyQuery = $this->buildBatchGraphqlDocument($type, $operations);
+        $url = $this->getEndpointUri('/graphql');
+        $body = json_encode(['query' => $readyQuery]);
+
+        $this->lastRequest = $this->requestFactory->createRequest('POST', $url)
+            ->withHeader('Content-Type', 'application/json; charset=utf-8')
+            ->withHeader('Accept', 'application/json')
+            ->withHeader('Accept-Encoding', '*')
+            ->withHeader('Authorization', 'Bearer ' . $this->getAccessToken())
+            ->withBody($this->streamFactory->createStream($body));
+
+        $this->logger->debug('GQLBatchRequest: '.$readyQuery, [$url]);
+        $this->lastResponse = $this->httpClient->sendRequest($this->lastRequest);
+        $responseBody = (string)$this->lastResponse->getBody();
+        $this->logger->debug('GQLBatchResponse: '.$responseBody, [$url]);
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if($statusCode >= 200 && $statusCode < 400) {
+            $res = json_decode($responseBody, true);
+            $res = $this->decode($res);
+            if(isset($res['error']) || isset($res['errors'])) {
+                $this->logger->warning('GQLBatchError: '.$responseBody, [$url, $body]);
+                throw new ErrorException($this->lastRequest, $this->lastResponse);
+            }
+
+            $data = $res['data'] ?? [];
+            if($throwOnOperationErrors) {
+                foreach($data as $alias => $operationResponse) {
+                    if(!empty($operationResponse['errors'])) {
+                        $this->logger->warning('GQLBatchOperationError: '.$responseBody, [$url, $body, $alias]);
+                        throw new ErrorException($this->lastRequest, $this->lastResponse);
+                    }
+                }
+            }
+
+            return $data;
+        }
+        elseif($statusCode >= 400 && $statusCode <= 403) {
+            $this->logger->warning($statusCode.': '.$responseBody, [$url, $body]);
+            throw new AuthenticationException($this->lastRequest, $this->lastResponse);
+        }
+        else {
+            $this->logger->error($statusCode.': '.$responseBody, [$url, $body]);
+            throw new ServerException($this->lastRequest, $this->lastResponse);
+        }
+    }
+
+    protected function buildBatchGraphqlDocument(string $type, array $operations): string
+    {
+        if(!in_array($type, ['query', 'mutation'])) {
+            throw new \InvalidArgumentException('Batch GraphQL type must be query or mutation.');
+        }
+
+        if(empty($operations)) {
+            throw new \InvalidArgumentException('At least one batch operation is required.');
+        }
+
+        $fields = [];
+        foreach($operations as $alias => $operation) {
+            if(!is_array($operation)) {
+                throw new \InvalidArgumentException('Each batch operation must be an array.');
+            }
+
+            if(is_int($alias)) {
+                $alias = $operation['alias'] ?? null;
+            }
+
+            if(!is_string($alias) || !$this->isValidGraphqlName($alias)) {
+                throw new \InvalidArgumentException('Each batch operation alias must be a valid GraphQL name.');
+            }
+
+            $method = $operation['method'] ?? null;
+            if(!is_string($method) || !$this->isValidGraphqlName($method)) {
+                throw new \InvalidArgumentException("Batch operation '{$alias}' has invalid method name.");
+            }
+
+            $arguments = $operation['arguments'] ?? [];
+            $body = $operation['body'] ?? [];
+            if(!is_array($arguments) || !is_array($body)) {
+                throw new \InvalidArgumentException("Batch operation '{$alias}' arguments and body must be arrays.");
+            }
+
+            if(isset($body['data']) && !in_array('errors', $body)) {
+                $body[] = 'errors';
+            }
+
+            $fields[] = sprintf(
+                '%s: %s%s%s',
+                $alias,
+                $method,
+                $this->buildGraphqlArgumentsString($arguments),
+                $this->buildGraphqlBodyString($body)
+            );
+        }
+
+        return sprintf("%s {\n%s\n}", $type, implode("\n", $fields));
+    }
+
+    protected function buildGraphqlArgumentsString(array $arguments): string
+    {
+        if(empty($arguments)) {
+            return '';
+        }
+
+        $encodedArguments = $this->encode($arguments);
+        $argumentKeys = [];
+        $enumValues = [];
+        $this->collectGraphqlArgumentMetadata($encodedArguments, $argumentKeys, $enumValues);
+
+        $args = json_encode($encodedArguments, JSON_UNESCAPED_UNICODE);
+        $args = sprintf('(%s)', substr($args, 1, strlen($args) - 2));
+
+        foreach($argumentKeys as $argumentKey) {
+            $args = str_replace(sprintf('"%s":', $argumentKey), sprintf('%s:', $argumentKey), $args);
+        }
+
+        foreach($enumValues as $enumValue) {
+            $args = str_replace(sprintf('"%s"', $enumValue), $enumValue, $args);
+        }
+
+        return $args;
+    }
+
+    protected function collectGraphqlArgumentMetadata(array $arguments, array &$argumentKeys, array &$enumValues): void
+    {
+        foreach($arguments as $argumentName => $argumentValue) {
+            if(is_string($argumentName) && !is_numeric($argumentName)) {
+                $argumentKeys[$argumentName] = $argumentName;
+            }
+
+            if(is_array($argumentValue)) {
+                $this->collectGraphqlArgumentMetadata($argumentValue, $argumentKeys, $enumValues);
+            }
+            elseif(is_string($argumentValue) && $argumentValue === strtoupper($argumentValue) && strpos($argumentValue, 'ENUM_') !== false) {
+                $enumValues[$argumentValue] = $argumentValue;
+            }
+        }
+    }
+
+    protected function buildGraphqlBodyString(array $body): string
+    {
+        if(empty($body)) {
+            return '';
+        }
+
+        $bodyString = " {\n";
+        $this->appendGraphqlBodyFields($body, $bodyString);
+        $bodyString .= "}\n";
+
+        return $bodyString;
+    }
+
+    protected function appendGraphqlBodyFields(array $fields, string &$bodyString): void
+    {
+        foreach($fields as $key => $field) {
+            if(is_int($key)) {
+                $bodyString .= $field . "\n";
+            }
+            elseif(is_string($key) && is_array($field)) {
+                $bodyString .= $key . " {\n";
+                $this->appendGraphqlBodyFields($field, $bodyString);
+                $bodyString .= "}\n";
+            }
+        }
+    }
+
+    protected function isValidGraphqlName(string $name): bool
+    {
+        return preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name) === 1;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2,10 +2,16 @@
 
 use Depoto\Client;
 use Depoto\Exception\AuthenticationException;
+use Depoto\Exception\ErrorException;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\NullLogger;
+use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\HttpClient\Psr18Client;
@@ -24,6 +30,26 @@ class ClientTest extends TestCase
             ->setBaseUrl('https://server-dev.depoto.cz/app_dev.php')
             ->setUsername('test@depoto.cz')
             ->setPassword('besttest');
+
+        return $depotoClient;
+    }
+
+    private function getBatchTestClient(RecordingHttpClient $httpClient, InMemoryCache $cache): Client
+    {
+        $psr17Factory = new Psr17Factory();
+        $username = 'unit@example.com';
+
+        $cache->set('depoto-oauth-'.md5($username), [
+            'access_token' => 'test-token',
+            'refresh_token' => 'test-refresh-token',
+            'expires_time' => time() + 3600,
+        ]);
+
+        $depotoClient = new Client($httpClient, $psr17Factory, $psr17Factory, $cache, new NullLogger());
+        $depotoClient
+            ->setBaseUrl('https://example.test')
+            ->setUsername($username)
+            ->setPassword('unused');
 
         return $depotoClient;
     }
@@ -75,5 +101,178 @@ class ClientTest extends TestCase
         $this->assertArrayHasKey('id', $product['data']);
         $this->assertArrayHasKey('name', $product['data']);
         $this->assertEquals($name, $product['data']['name']);
+    }
+
+    public function testBatchQueryBuildsGraphqlRequestDocument(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $httpClient = new RecordingHttpClient([
+            $psr17Factory->createResponse(200)->withBody($psr17Factory->createStream(json_encode([
+                'data' => [
+                    'firstProduct' => ['data' => ['id' => '1', 'name' => 'Product']],
+                    'productList' => ['items' => [['id' => '2', 'name' => 'Another product']]],
+                ],
+            ]))),
+        ]);
+
+        $result = $this->getBatchTestClient($httpClient, new InMemoryCache())->batchQuery([
+            'firstProduct' => [
+                'method' => 'product',
+                'arguments' => [
+                    'id' => 123,
+                    'filters' => [
+                        'type' => 'ENUM_ACTIVE',
+                        'includeDeleted' => false,
+                    ],
+                ],
+                'body' => [
+                    'data' => [
+                        'id',
+                        'name',
+                        'variants' => ['id', 'sku'],
+                    ],
+                ],
+            ],
+            'productList' => [
+                'method' => 'products',
+                'arguments' => [
+                    'filters' => ['fulltext' => 'summer shirt'],
+                ],
+                'body' => [
+                    'items' => ['id', 'name'],
+                ],
+            ],
+        ]);
+
+        $this->assertSame('Product', $result['firstProduct']['data']['name']);
+        $this->assertCount(1, $httpClient->requests);
+
+        $request = $httpClient->requests[0];
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('https://example.test/graphql', (string)$request->getUri());
+        $this->assertSame('Bearer test-token', $request->getHeaderLine('Authorization'));
+
+        $requestBody = json_decode((string)$request->getBody(), true);
+        $this->assertIsArray($requestBody);
+        $this->assertArrayHasKey('query', $requestBody);
+
+        $query = $requestBody['query'];
+        $this->assertStringContainsString('query {', $query);
+        $this->assertStringContainsString('firstProduct: product(id:"123",filters:{type:ENUM_ACTIVE,includeDeleted:false})', $query);
+        $this->assertStringContainsString('data {', $query);
+        $this->assertStringContainsString('variants {', $query);
+        $this->assertStringContainsString('errors', $query);
+        $this->assertStringContainsString('productList: products(filters:{fulltext:"summer+shirt"})', $query);
+        $this->assertStringContainsString('items {', $query);
+    }
+
+    public function testBatchMutationCanThrowOnOperationErrors(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $httpClient = new RecordingHttpClient([
+            $psr17Factory->createResponse(200)->withBody($psr17Factory->createStream(json_encode([
+                'data' => [
+                    'createProduct' => [
+                        'data' => null,
+                        'errors' => ['Name is required'],
+                    ],
+                ],
+            ]))),
+        ]);
+
+        $this->expectException(ErrorException::class);
+
+        $this->getBatchTestClient($httpClient, new InMemoryCache())->batchMutation([
+            'createProduct' => [
+                'method' => 'createProduct',
+                'arguments' => ['name' => ''],
+                'body' => ['data' => ['id', 'name']],
+            ],
+        ], true);
+    }
+}
+
+class RecordingHttpClient implements ClientInterface
+{
+    /** @var RequestInterface[] */
+    public array $requests = [];
+
+    /** @var ResponseInterface[] */
+    private array $responses;
+
+    public function __construct(array $responses)
+    {
+        $this->responses = $responses;
+    }
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $this->requests[] = $request;
+
+        return array_shift($this->responses);
+    }
+}
+
+class InMemoryCache implements CacheInterface
+{
+    private array $items = [];
+
+    public function get($key, $default = null)
+    {
+        return $this->items[$key] ?? $default;
+    }
+
+    public function set($key, $value, $ttl = null)
+    {
+        $this->items[$key] = $value;
+
+        return true;
+    }
+
+    public function delete($key)
+    {
+        unset($this->items[$key]);
+
+        return true;
+    }
+
+    public function clear()
+    {
+        $this->items = [];
+
+        return true;
+    }
+
+    public function getMultiple($keys, $default = null)
+    {
+        $values = [];
+        foreach($keys as $key) {
+            $values[$key] = $this->get($key, $default);
+        }
+
+        return $values;
+    }
+
+    public function setMultiple($values, $ttl = null)
+    {
+        foreach($values as $key => $value) {
+            $this->set($key, $value, $ttl);
+        }
+
+        return true;
+    }
+
+    public function deleteMultiple($keys)
+    {
+        foreach($keys as $key) {
+            $this->delete($key);
+        }
+
+        return true;
+    }
+
+    public function has($key)
+    {
+        return array_key_exists($key, $this->items);
     }
 }


### PR DESCRIPTION
 Adds batch GraphQL support to `Depoto\Client` via `batchQuery()` and `batchMutation()`, allowing multiple
  aliased GraphQL operations to be sent in a single `/graphql` request.

  This is useful when the caller needs to fetch or update several resources at once while still receiving
  responses keyed by operation alias.

## Batch Mutation Example

```php
  $result = $client->batchMutation([
      'updateProductOne' => [
          'method' => 'updateProduct',
          'arguments' => [
              'id' => 123,
              'name' => 'Updated product one',
          ],
          'body' => [
              'data' => ['id', 'name'],
          ],
      ],
      'updateProductTwo' => [
          'method' => 'updateProduct',
          'arguments' => [
              'id' => 456,
              'name' => 'Updated product two',
          ],
          'body' => [
              'data' => ['id', 'name'],
          ],
      ],
  ]);
```

  Generated GraphQL shape:

```graphql
  mutation {
    updateProductOne: updateProduct(id: "123", name: "Updated product one") {
      data {
        id
        name
      }
      errors
    }

    updateProductTwo: updateProduct(id: "456", name: "Updated product two") {
      data {
        id
        name
      }
      errors
    }
  }
```

  The response is returned by alias, for example $result['productOne'] or $result['updateProductTwo'].


## Batch Query Example

  ```php
  $result = $client->batchQuery([
      'productOne' => [
          'method' => 'product',
          'arguments' => ['id' => 123],
          'body' => [
              'data' => ['id', 'name', 'sku'],
          ],
      ],
      'productTwo' => [
          'method' => 'product',
          'arguments' => ['id' => 456],
          'body' => [
              'data' => ['id', 'name', 'sku'],
          ],
      ],
  ]);
```

Generated GraphQL shape:

```graphql
  

  query {
    productOne: product(id: "123") {
      data {
        id
        name
        sku
      }
      errors
    }

    productTwo: product(id: "456") {
      data {
        id
        name
        sku
      }
      errors
    }
  }
```